### PR TITLE
WorkerException thrown from task is handled in RecordStatusObserver

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <packaging>jar</packaging>
 
     <name>kafka-workers</name>
-    <version>1.0.9</version>
+    <version>1.0.10-SNAPSHOT</version>
     <url>https://github.com/RTBHOUSE/kafka-workers</url>
 
     <description>Kafka's client library.</description>

--- a/src/main/java/com/rtbhouse/kafka/workers/impl/task/WorkerTaskImpl.java
+++ b/src/main/java/com/rtbhouse/kafka/workers/impl/task/WorkerTaskImpl.java
@@ -47,8 +47,6 @@ public class WorkerTaskImpl<K, V> implements WorkerTask<K, V> {
         metrics.recordSensor(WorkersMetrics.PROCESSING_OFFSET_METRIC, subpartition, record.offset());
         try {
             task.process(record, observer);
-        } catch (WorkersException e) {
-            throw e;
         } catch (Exception e) {
             observer.onFailure(e);
         }

--- a/src/test/java/com/rtbhouse/kafka/workers/integration/ProcessingFailureTest.java
+++ b/src/test/java/com/rtbhouse/kafka/workers/integration/ProcessingFailureTest.java
@@ -91,7 +91,9 @@ public class ProcessingFailureTest {
         // then
         assertThat(latch.await(10, TimeUnit.SECONDS)).isTrue();
         assertThat(exceptions.size()).isEqualTo(1);
-        assertThat(exceptions.get(0)).isExactlyInstanceOf(ProcessingFailureException.class);
+        Throwable t;
+        for (t = exceptions.get(0); t.getCause() != null; t = t.getCause());
+        assertThat(t).isExactlyInstanceOf(TestException.class);
     }
 
     private static class TestTask implements WorkerTask<String, String> {
@@ -101,12 +103,18 @@ public class ProcessingFailureTest {
         @Override
         public void process(WorkerRecord<String, String> record, RecordStatusObserver observer) {
             if (count == RECORD_TO_FAIL) {
-                throw new ProcessingFailureException("sample failure test on record: " + count);
+                throw new TestException("sample failure test on record: " + count);
             }
             count++;
             observer.onSuccess();
         }
 
+    }
+
+    private static class TestException extends RuntimeException {
+        public TestException(String message) {
+            super(message);
+        }
     }
 
     private static class TestTaskFactory implements WorkerTaskFactory<String, String> {


### PR DESCRIPTION
Prior to this change WorkerExceptions thrown from WorkerTasks were handled on a WorkerTaskImpl level and rethrown causing Kafka Workers to stop, what as a result caused processing guarantee "none" to be effectively identical to "at least once". This change unifies  handling of WorkersException's originating froms tasks, placing it solely in RecordStatusObserverImpl.