### PR TITLE
punctuate() method added to WorkerTask API

### DIFF
--- a/src/main/java/com/rtbhouse/kafka/workers/api/WorkersConfig.java
+++ b/src/main/java/com/rtbhouse/kafka/workers/api/WorkersConfig.java
@@ -95,6 +95,13 @@ public class WorkersConfig extends AbstractConfig {
     public static final String WORKER_TASK_PREFIX = "worker.task.";
 
     /**
+     * The frequency in milliseconds that punctuate method is called.
+     */
+    public static final String PUNCTUATOR_INTERVAL_MS = "punctuator.interval.ms";
+    private static final String PUNCTUATOR_INTERVAL_MS_DOC = "The frequency in milliseconds that punctuate method is called.";
+    private static final long PUNCTUATOR_INTERVAL_MS_DEFAULT = Duration.of(1, ChronoUnit.SECONDS).toMillis();
+
+    /**
      * Max size in bytes for single {@link WorkerSubpartition}'s internal queue.
      */
     public static final String QUEUE_MAX_SIZE_BYTES = "queue.max.size.bytes";
@@ -165,6 +172,11 @@ public class WorkersConfig extends AbstractConfig {
                         },
                         Importance.MEDIUM,
                         WORKER_PROCESSING_GUARANTEE_DOC)
+                .define(PUNCTUATOR_INTERVAL_MS,
+                        Type.LONG,
+                        PUNCTUATOR_INTERVAL_MS_DEFAULT,
+                        Importance.MEDIUM,
+                        PUNCTUATOR_INTERVAL_MS_DOC)
                 .define(QUEUE_MAX_SIZE_BYTES,
                         Type.LONG,
                         QUEUE_MAX_SIZE_BYTES_DEFAULT,
@@ -197,7 +209,6 @@ public class WorkersConfig extends AbstractConfig {
 
     private void checkConfigFinals(String prefix, Map<String, Object> finals) {
         Map<String, Object> configs = originalsWithPrefix(prefix);
-        ;
         for (Map.Entry<String, Object> override : finals.entrySet()) {
             var value = configs.get(override.getKey());
             checkState(value == null || value.equals(override.getValue()), "Config [%s] should be set to [%s]",

--- a/src/main/java/com/rtbhouse/kafka/workers/api/task/WorkerTask.java
+++ b/src/main/java/com/rtbhouse/kafka/workers/api/task/WorkerTask.java
@@ -50,6 +50,16 @@ public interface WorkerTask<K, V> {
     void process(WorkerRecord<K, V> record, RecordStatusObserver observer);
 
     /**
+     * Allows to do maintenance tasks every configurable amount of time independently if there are records to process or not.
+     * All the methods: accept(), process() and punctuate() are executed in a single thread so synchronization is not necessary.
+     *
+     * @param punctuateTime
+     *              current time when punctuate() is called
+     */
+    default void punctuate(long punctuateTime) {
+    }
+
+    /**
      * Will be called every time when given {@link WorkerSubpartition} is being revoked from {@code KafkaWorkers}
      * instance.
      */

--- a/src/main/java/com/rtbhouse/kafka/workers/impl/punctuator/PunctuatorThread.java
+++ b/src/main/java/com/rtbhouse/kafka/workers/impl/punctuator/PunctuatorThread.java
@@ -1,0 +1,46 @@
+package com.rtbhouse.kafka.workers.impl.punctuator;
+
+import com.rtbhouse.kafka.workers.api.WorkersConfig;
+import com.rtbhouse.kafka.workers.impl.AbstractWorkersThread;
+import com.rtbhouse.kafka.workers.impl.KafkaWorkersImpl;
+import com.rtbhouse.kafka.workers.impl.metrics.WorkersMetrics;
+import com.rtbhouse.kafka.workers.impl.task.WorkerThread;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.List;
+
+public class PunctuatorThread<K, V> extends AbstractWorkersThread {
+
+    private static final Logger logger = LoggerFactory.getLogger(PunctuatorThread.class);
+
+    private final List<WorkerThread<K, V>> threads;
+
+    public PunctuatorThread(
+            WorkersConfig config,
+            WorkersMetrics metrics,
+            KafkaWorkersImpl<K, V> workers,
+            List<WorkerThread<K, V>> threads) {
+        super("punctuator-thread", config, metrics, workers);
+        this.threads = threads;
+    }
+
+    @Override
+    public void init() {
+    }
+
+    @Override
+    public void process() throws InterruptedException {
+        for (WorkerThread<K, V> thread : threads) {
+            if (thread.shouldPunctuateNow()) {
+                thread.notifyThread();
+            }
+        }
+        Thread.sleep(config.getLong(WorkersConfig.PUNCTUATOR_INTERVAL_MS));
+    }
+
+    @Override
+    public void close() {
+    }
+
+}

--- a/src/main/java/com/rtbhouse/kafka/workers/impl/task/WorkerTaskImpl.java
+++ b/src/main/java/com/rtbhouse/kafka/workers/impl/task/WorkerTaskImpl.java
@@ -53,6 +53,11 @@ public class WorkerTaskImpl<K, V> implements WorkerTask<K, V> {
     }
 
     @Override
+    public void punctuate(long punctuateTime) {
+        task.punctuate(punctuateTime);
+    }
+
+    @Override
     public void close() {
         task.close();
         metrics.removeWorkerThreadSubpartitionMetrics(subpartition);

--- a/src/test/java/com/rtbhouse/kafka/workers/impl/task/TaskManagerTest.java
+++ b/src/test/java/com/rtbhouse/kafka/workers/impl/task/TaskManagerTest.java
@@ -56,7 +56,6 @@ public class TaskManagerTest {
         // given
         WorkerRecord<byte[], byte[]> record = new WorkerRecord<>(new ConsumerRecord<>("topic", 0, 0L, null, null), 0);
         when(queueManager.peek(any())).thenReturn(record);
-        when(queueManager.poll(any())).thenReturn(record);
 
         WorkerTaskFactory<byte[], byte[]> taskFactory = new TaskFactory();
         SubpartitionSupplier<byte[], byte[]> subpartitionSupplier = new SubpartitionSupplier<>(new RoundRobinPartitioner<>(10));

--- a/src/test/java/com/rtbhouse/kafka/workers/integration/PunctuateTest.java
+++ b/src/test/java/com/rtbhouse/kafka/workers/integration/PunctuateTest.java
@@ -1,0 +1,124 @@
+package com.rtbhouse.kafka.workers.integration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.util.Properties;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.kafka.clients.producer.KafkaProducer;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.rtbhouse.kafka.workers.api.KafkaWorkers;
+import com.rtbhouse.kafka.workers.api.WorkersConfig;
+import com.rtbhouse.kafka.workers.api.record.RecordStatusObserver;
+import com.rtbhouse.kafka.workers.api.record.WorkerRecord;
+import com.rtbhouse.kafka.workers.api.task.WorkerTask;
+import com.rtbhouse.kafka.workers.api.task.WorkerTaskFactory;
+import com.rtbhouse.kafka.workers.integration.utils.KafkaServerRule;
+import com.rtbhouse.kafka.workers.integration.utils.RequiresKafkaServer;
+import com.rtbhouse.kafka.workers.integration.utils.TestProperties;
+import com.rtbhouse.kafka.workers.integration.utils.ZookeeperUtils;
+
+@RequiresKafkaServer
+public class PunctuateTest {
+
+    private static final Logger logger = LoggerFactory.getLogger(PunctuateTest.class);
+
+    private static final String TOPIC = "topic";
+    private static final int RECORDS_COUNT = 100;
+
+    private static final Properties SERVER_PROPERTIES = TestProperties.serverProperties();
+
+    private static final Properties WORKERS_PROPERTIES = TestProperties.workersProperties(
+            StringDeserializer.class, StringDeserializer.class, TOPIC);
+    static {
+        WORKERS_PROPERTIES.put(WorkersConfig.PUNCTUATOR_INTERVAL_MS, 100L);
+    }
+
+    private static final Properties PRODUCER_PROPERTIES = TestProperties.producerProperties(
+            StringSerializer.class, StringSerializer.class);
+
+    @Rule
+    public KafkaServerRule kafkaServerRule = new KafkaServerRule(SERVER_PROPERTIES);
+
+    private KafkaProducer<String, String> producer;
+
+    @Before
+    public void before() throws Exception {
+        ZookeeperUtils.createTopics(kafkaServerRule.getZookeeperConnectString(), 1, 1, TOPIC);
+        producer = new KafkaProducer<>(PRODUCER_PROPERTIES);
+    }
+
+    @After
+    public void after() throws IOException {
+        producer.close();
+    }
+
+    @Test
+    public void shouldShutdownWorkers() throws Exception {
+
+        // given
+        for (int i = 0; i < RECORDS_COUNT; i++) {
+            producer.send(new ProducerRecord<>(TOPIC, 0, null, "key_" + i, "value_" + i));
+        }
+
+        CountDownLatch latch = new CountDownLatch(5);
+
+        KafkaWorkers<String, String> kafkaWorkers = new KafkaWorkers<>(
+                new WorkersConfig(WORKERS_PROPERTIES),
+                new TestTaskFactory(latch));
+
+        // when
+        kafkaWorkers.start();
+
+        // then
+        assertThat(latch.await(10, TimeUnit.SECONDS)).isTrue();
+
+    }
+
+    private static class TestTask implements WorkerTask<String, String> {
+
+        private CountDownLatch latch;
+
+        public TestTask(CountDownLatch latch) {
+            this.latch = latch;
+        }
+
+        @Override
+        public void process(WorkerRecord<String, String> record, RecordStatusObserver observer) {
+            observer.onSuccess();
+        }
+
+        @Override
+        public void punctuate(long punctuateTime) {
+            logger.info("punctuate(punctuateTime: {})", punctuateTime);
+            latch.countDown();
+        }
+    }
+
+    private static class TestTaskFactory implements WorkerTaskFactory<String, String> {
+
+        private CountDownLatch latch;
+
+        public TestTaskFactory(CountDownLatch latch) {
+            this.latch = latch;
+        }
+
+        @Override
+        public TestTask createTask(WorkersConfig config) {
+            return new TestTask(latch);
+        }
+
+    }
+
+}


### PR DESCRIPTION
Allows to do maintenance tasks every configurable amount of time independently if there are records to process or not. All the methods: accept(), process() and punctuate() are executed in a single thread so synchronization is not necessary.