### PR TITLE
AbstractWorkersThread's resource cleanup to be invoked sequentially.

### DIFF
--- a/src/main/java/com/rtbhouse/kafka/workers/impl/AbstractWorkersThread.java
+++ b/src/main/java/com/rtbhouse/kafka/workers/impl/AbstractWorkersThread.java
@@ -19,7 +19,7 @@ public abstract class AbstractWorkersThread extends Thread {
     protected volatile boolean shutdown = false;
     private volatile WorkersException exception;
 
-    protected volatile boolean closed = false;
+    protected volatile boolean stopped = false;
 
     public AbstractWorkersThread(String name, WorkersConfig config, WorkersMetrics metrics, KafkaWorkersImpl<?, ?> workers) {
         super(name);
@@ -64,13 +64,9 @@ public abstract class AbstractWorkersThread extends Thread {
             logger.error("Thread shuts down KafkaWorkers", e);
             workers.shutdown(wrapIfNeeded(e));
         } finally {
-            try {
-                close();
-            } finally {
-                closed = true;
-            }
+            stopped = true;
         }
-        logger.info("thread {} closed", name);
+        logger.info("thread {} stopped", name);
     }
 
     private WorkersException wrapIfNeeded(Throwable e) {

--- a/src/main/java/com/rtbhouse/kafka/workers/impl/task/TaskManager.java
+++ b/src/main/java/com/rtbhouse/kafka/workers/impl/task/TaskManager.java
@@ -116,7 +116,7 @@ public class TaskManager<K, V> implements Partitioned {
     }
 
     private boolean allThreadsStopped() {
-        return threads.stream().allMatch(WorkerThread::isStopped);
+        return threads.stream().allMatch(WorkerThread::isNotRunning);
     }
 
 }

--- a/src/main/java/com/rtbhouse/kafka/workers/impl/task/WorkerTaskImpl.java
+++ b/src/main/java/com/rtbhouse/kafka/workers/impl/task/WorkerTaskImpl.java
@@ -1,7 +1,6 @@
 package com.rtbhouse.kafka.workers.impl.task;
 
 import com.rtbhouse.kafka.workers.api.WorkersConfig;
-import com.rtbhouse.kafka.workers.api.WorkersException;
 import com.rtbhouse.kafka.workers.api.partitioner.WorkerSubpartition;
 import com.rtbhouse.kafka.workers.api.record.RecordStatusObserver;
 import com.rtbhouse.kafka.workers.api.record.WorkerRecord;

--- a/src/main/java/com/rtbhouse/kafka/workers/impl/task/WorkerThread.java
+++ b/src/main/java/com/rtbhouse/kafka/workers/impl/task/WorkerThread.java
@@ -134,8 +134,8 @@ public class WorkerThread<K, V> extends AbstractWorkersThread {
         return tasks.size();
     }
 
-    public boolean isStopped() {
-        return waiting || closed;
+    public boolean isNotRunning() {
+        return waiting || stopped;
     }
 
     public synchronized void notifyThread() {


### PR DESCRIPTION
The previous sequence prevented the remaining processed by WorkerTask's offsets to be commited when close is invoked.