### PR TITLE
Add worker thread assignor

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ The last but not least was simplicity (lightweight library, with almost pure Kaf
 
 ## Version
 
-Current version is **1.1.7**
+Current version is **1.1.8**
 
 ## Requirements
 
@@ -39,7 +39,7 @@ Releases are distributed on [mvn repository](https://mvnrepository.com/artifact/
 <dependency>
     <groupId>com.rtbhouse</groupId>
     <artifactId>kafka-workers</artifactId>
-    <version>1.1.7</version>
+    <version>1.1.8</version>
 </dependency>
 ```
 

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <packaging>jar</packaging>
 
     <name>kafka-workers</name>
-    <version>1.1.7</version>
+    <version>1.1.8</version>
     <url>https://github.com/RTBHOUSE/kafka-workers</url>
 
     <description>Kafka's client library.</description>

--- a/src/main/java/com/rtbhouse/kafka/workers/impl/task/SpreadSubpartitionsWorkerThreadAssignor.java
+++ b/src/main/java/com/rtbhouse/kafka/workers/impl/task/SpreadSubpartitionsWorkerThreadAssignor.java
@@ -1,0 +1,41 @@
+package com.rtbhouse.kafka.workers.impl.task;
+
+import com.rtbhouse.kafka.workers.api.partitioner.WorkerSubpartition;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class SpreadSubpartitionsWorkerThreadAssignor<K, V> implements WorkerThreadAssignor<K, V> {
+
+    private static final Comparator<WorkerSubpartition> COMPARATOR = Comparator.comparing(WorkerSubpartition::topic)
+            .thenComparingInt(WorkerSubpartition::partition)
+            .thenComparingInt(WorkerSubpartition::subpartition);
+
+    @Override
+    public Map<WorkerThread<K, V>, List<WorkerSubpartition>> assign(Collection<WorkerSubpartition> subpartitions,
+            List<WorkerThread<K, V>> threads) {
+        final List<WorkerSubpartition> sortedSubpartitions = new ArrayList<>(subpartitions);
+        sortedSubpartitions.sort(COMPARATOR);
+        final Map<WorkerThread<K, V>, List<WorkerSubpartition>> assignment = new HashMap<>();
+        int index = 0;
+        for (WorkerSubpartition workerSubpartition : sortedSubpartitions) {
+            final WorkerThread<K, V> workerThread = threads.get(index);
+            assignment.compute(workerThread, (thread, assignments) -> {
+                if (assignments == null) {
+                    final List<WorkerSubpartition> list = new ArrayList<>();
+                    list.add(workerSubpartition);
+                    return list;
+                } else {
+                    assignments.add(workerSubpartition);
+                    return assignments;
+                }
+            });
+            index = (index + 1) % threads.size();
+        }
+        return assignment;
+    }
+}

--- a/src/main/java/com/rtbhouse/kafka/workers/impl/task/WorkerThreadAssignor.java
+++ b/src/main/java/com/rtbhouse/kafka/workers/impl/task/WorkerThreadAssignor.java
@@ -1,0 +1,23 @@
+package com.rtbhouse.kafka.workers.impl.task;
+
+import com.rtbhouse.kafka.workers.api.partitioner.WorkerSubpartition;
+import com.rtbhouse.kafka.workers.impl.task.WorkerThread;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Assignor used for assigning {@link WorkerSubpartition} to {@link WorkerThread}.
+ */
+public interface WorkerThreadAssignor<K, V> {
+
+    /**
+     * Determines assignments between subpartitions and worker threads.
+     * @param subpartitions subpartitions to be assigned.
+     * @param threads worker threads collection.
+     * @return subpartitions assigned to each thread.
+     */
+    Map<WorkerThread<K, V>, List<WorkerSubpartition>> assign(Collection<WorkerSubpartition> subpartitions,
+            List<WorkerThread<K, V>> threads);
+}

--- a/src/test/java/com/rtbhouse/kafka/workers/impl/task/WorkerThreadAssignorTest.java
+++ b/src/test/java/com/rtbhouse/kafka/workers/impl/task/WorkerThreadAssignorTest.java
@@ -1,0 +1,100 @@
+package com.rtbhouse.kafka.workers.impl.task;
+
+import com.rtbhouse.kafka.workers.api.partitioner.WorkerSubpartition;
+import com.rtbhouse.kafka.workers.impl.task.SpreadSubpartitionsWorkerThreadAssignor;
+import com.rtbhouse.kafka.workers.impl.task.WorkerThread;
+import com.rtbhouse.kafka.workers.impl.task.WorkerThreadAssignor;
+import org.apache.kafka.common.TopicPartition;
+import org.assertj.core.api.Assertions;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import java.util.List;
+import java.util.Map;
+
+public class WorkerThreadAssignorTest {
+
+    @Test
+    public void shouldSpreadSubpartitionsAsFairAsPossible() {
+        final WorkerThreadAssignor<Object, Object> workerThreadAssignor = new SpreadSubpartitionsWorkerThreadAssignor<>();
+
+        final WorkerThread<Object, Object> workerThread1 = Mockito.mock(WorkerThread.class);
+        final WorkerThread<Object, Object> workerThread2 = Mockito.mock(WorkerThread.class);
+
+        // when
+        final Map<WorkerThread<Object, Object>, List<WorkerSubpartition>> assignments = workerThreadAssignor.assign(List.of(
+                getSubpartition("topic_a", 0, 0),
+                getSubpartition("topic_b", 0, 0),
+                getSubpartition("topic_a", 0, 1),
+                getSubpartition("topic_b", 0, 1),
+                getSubpartition("topic_a", 0, 2),
+                getSubpartition("topic_b", 0, 2)
+        ), List.of(workerThread1, workerThread2));
+
+        // then
+        Assertions.assertThat(assignments).containsValues(
+                List.of(
+                        getSubpartition("topic_a", 0, 0),
+                        getSubpartition("topic_a", 0, 2),
+                        getSubpartition("topic_b", 0, 1)
+                ),
+                List.of(
+                        getSubpartition("topic_a", 0, 1),
+                        getSubpartition("topic_b", 0, 0),
+                        getSubpartition("topic_b", 0, 2)
+                )
+        );
+    }
+
+    @Test
+    public void shouldSpreadSubpartitionsAsFairAsPossible2() {
+        final WorkerThreadAssignor<Object, Object> workerThreadAssignor = new SpreadSubpartitionsWorkerThreadAssignor<>();
+
+        final WorkerThread<Object, Object> workerThread1 = Mockito.mock(WorkerThread.class);
+        final WorkerThread<Object, Object> workerThread2 = Mockito.mock(WorkerThread.class);
+        final WorkerThread<Object, Object> workerThread3 = Mockito.mock(WorkerThread.class);
+
+        // when
+        final Map<WorkerThread<Object, Object>, List<WorkerSubpartition>> assignments = workerThreadAssignor.assign(List.of(
+                getSubpartition("topic_a", 0, 3),
+                getSubpartition("topic_a", 0, 1),
+                getSubpartition("topic_a", 0, 0),
+                getSubpartition("topic_a", 0, 2),
+                getSubpartition("topic_a", 1, 0),
+                getSubpartition("topic_a", 1, 2),
+                getSubpartition("topic_a", 1, 1),
+                getSubpartition("topic_a", 1, 3),
+                getSubpartition("topic_b", 1, 3),
+                getSubpartition("topic_b", 1, 1),
+                getSubpartition("topic_b", 1, 0),
+                getSubpartition("topic_b", 1, 2)
+        ), List.of(workerThread1, workerThread2, workerThread3));
+
+        // then
+        Assertions.assertThat(assignments).containsValues(
+                List.of(
+                        getSubpartition("topic_a", 0, 0),
+                        getSubpartition("topic_a", 0, 3),
+                        getSubpartition("topic_a", 1, 2),
+                        getSubpartition("topic_b", 1, 1)
+                ),
+                List.of(
+                        getSubpartition("topic_a", 0, 1),
+                        getSubpartition("topic_a", 1, 0),
+                        getSubpartition("topic_a", 1, 3),
+                        getSubpartition("topic_b", 1, 2)
+                ),
+                List.of(
+                        getSubpartition("topic_a", 0, 2),
+                        getSubpartition("topic_a", 1, 1),
+                        getSubpartition("topic_b", 1, 0),
+                        getSubpartition("topic_b", 1, 3)
+                )
+        );
+    }
+
+    private WorkerSubpartition getSubpartition(String topic, int partition, int subpartition) {
+        return WorkerSubpartition.getInstance(new TopicPartition(topic, partition), subpartition);
+    }
+
+}


### PR DESCRIPTION
Right now we assign subpartitions to threads using round robin strategy according to iteration order of partitionToTaskMap.values(). It would be nice to add more control over the assignment. Consider following situation:

1. KW instance consumes from multiple topics. 
2. Processing of topic A is more cpu consuming than processing of topic B.
3. Assume there are 2 worker threads. This is legal that more subpartitions from topic A will get assigned to one of threads resulting in one thread being less utilized.

In this PR I introduced WorkerThreadAssignor concept responsible for assigning subpartitions to worker threads. Default strategy remains the same but new one is available through config option.